### PR TITLE
Fix for user agents with leading or enclosing quotes

### DIFF
--- a/lib/user_agent.rb
+++ b/lib/user_agent.rb
@@ -6,9 +6,10 @@ require 'user_agent/version'
 class UserAgent
   # http://www.texsoft.it/index.php?m=sw.php.useragent
   MATCHER = %r{
-    ^([^/\s]+)        # Product
-    /?([^\s]*)        # Version
-    (\s\(([^\)]*)\))? # Comment
+    ^['"]*             # Possible opening quote(s)
+    ([^/\s]+)          # Product
+    /?([^\s]*)         # Version
+    (\s\(([^\)]*)\))?  # Comment
   }x.freeze
 
   DEFAULT_USER_AGENT = "Mozilla/4.0 (compatible)"

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -190,6 +190,26 @@ describe UserAgent, ".parse" do
     useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
     expect(UserAgent.parse("Mozilla (Macintosh)").application).to eq(useragent)
   end
+
+  it "should parse a double-quoted user-agent" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
+    expect(UserAgent.parse("\"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0\"").application).to eq(useragent)
+  end
+
+  it "should parse a user-agent with leading double-quote" do
+    useragent = UserAgent.new("Mozilla", "5.0", ["X11", "Linux x86_64", "rv:9.0"])
+    expect(UserAgent.parse("\"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/8.0").application).to eq(useragent)
+  end
+
+  it "should parse a single-quoted user-agent" do
+    useragent = UserAgent.new("Mozilla", "5.0", nil)
+    expect(UserAgent.parse("'Mozilla/5.0'").application).to eq(useragent)
+  end
+
+  it "should parse a user-agent with leading single-quote" do
+    useragent = UserAgent.new("Mozilla", "5.0", nil)
+    expect(UserAgent.parse("'Mozilla/5.0").application).to eq(useragent)
+  end
 end
 
 describe UserAgent::Browsers::Base, "#<" do


### PR DESCRIPTION
In examining my HTTP logs, I found user agents that were double-quoted and that had a single leading quote:

````
"Mozilla/5.0 (X11; Linux x86_64; rv:9.0) Gecko/20100101 Firefox/9.0"
'Mozilla/5.0
````

This pull request changes the regex match to ignore quotes and adds RSpec tests for these cases.

````
Finished in 0.16646 seconds (files took 0.27094 seconds to load)
733 examples, 0 failures
`````