### PR TITLE
Added support for Opera user agent strings from version 15 upwards (i.e. the WebKit based versions)

### DIFF
--- a/lib/user_agent/browsers.rb
+++ b/lib/user_agent/browsers.rb
@@ -14,7 +14,7 @@ class UserAgent
     }.freeze
 
     def self.all
-      [InternetExplorer, Chrome, Webkit, Opera, Gecko]
+      [InternetExplorer, Opera, Chrome, Webkit, Gecko]
     end
 
     def self.extend(array)

--- a/lib/user_agent/browsers/opera.rb
+++ b/lib/user_agent/browsers/opera.rb
@@ -3,7 +3,12 @@ class UserAgent
     class Opera < Base
       def self.extend?(agent)
         (agent.first && agent.first.product == 'Opera') ||
-          (agent.application && agent.application.product == 'Opera')
+          (agent.application && agent.application.product == 'Opera') ||
+            (agent.last && agent.last.product == 'OPR')
+      end
+
+      def browser
+        'Opera'
       end
 
       def version


### PR DESCRIPTION
To properly detect the WebKit-based Opera versions, some changes were needed, as these versions include Chrome in the user agent string (see example below). Opera is now identifier by the string `OPR`.

```
Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.65 Safari/537.36 OPR/26.0.1656.32
```

Full specs on >= v15 user agent strings can be found here: https://dev.opera.com/blog/opera-user-agent-strings-opera-15-and-beyond/