### PR TITLE
Added support for Pale Moon

### DIFF
--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -6,6 +6,7 @@ class UserAgent
       end
 
       GeckoBrowsers = %w(
+        PaleMoon
         Firefox
         Camino
         Iceweasel


### PR DESCRIPTION
Added detection of Pale Moon browser, which has user agent strings like these:

```
Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.2) Gecko/20150122 Firefox/31.9 PaleMoon/25.2.1
Mozilla/5.0 (Windows NT 6.1; rv:24.7) Gecko/20140907 Firefox/24.7 PaleMoon/24.7.2
Mozilla/5.0 (Windows NT 6.1; rv:15.3) Gecko/20121108 Firefox/15.3 PaleMoon/15.3
```