### PR TITLE
Adds ',gzip(gfe)' Literal To Comment Matcher

### DIFF
--- a/lib/user_agent.rb
+++ b/lib/user_agent.rb
@@ -6,9 +6,9 @@ require 'user_agent/version'
 class UserAgent
   # http://www.texsoft.it/index.php?m=sw.php.useragent
   MATCHER = %r{
-    ^([^/\s]+)        # Product
-    /?([^\s]*)        # Version
-    (\s\(([^\)]*)\))? # Comment
+    ^([^/\s]+)                     # Product
+    /?([^\s,]*)                    # Version
+    (\s\(([^\)]*)\)|,gzip\(gfe\))? # Comment
   }x.freeze
 
   DEFAULT_USER_AGENT = "Mozilla/4.0 (compatible)"

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -186,6 +186,12 @@ describe UserAgent, ".parse" do
     expect(UserAgent.parse("Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_3 ; en-us; )").application).to eq(useragent)
   end
 
+  it "should parse a user agent string with gzip(gfe) addition correctly" do
+    agent = UserAgent.parse("Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)")
+
+    expect(agent.version.to_s).to eq("35.0")
+  end
+
   it "should parse a single product and comment" do
     useragent = UserAgent.new("Mozilla", nil, ["Macintosh"])
     expect(UserAgent.parse("Mozilla (Macintosh)").application).to eq(useragent)


### PR DESCRIPTION
We're getting quite a few requests through with a User Agent String containing a suffix ",gzip(gfe)".

For example:

`Mozilla/5.0 (Windows NT 5.1; rv:35.0) Gecko/20100101 Firefox/35.0,gzip(gfe)`

Previously the matcher included the extra comment section in the Version number - this commit causes that string literal to be shifted over to the comment field. Included a test.