### PR TITLE
correcting 'Linux' to 'Android' for Chrome mobile case

### DIFF
--- a/lib/user_agent/browsers/chrome.rb
+++ b/lib/user_agent/browsers/chrome.rb
@@ -36,6 +36,8 @@ class UserAgent
           nil
         elsif application.comment[0] =~ /Windows/
           'Windows'
+        elsif application.comment[1] =~ /Android/
+          'Android'
         else
           application.comment[0]
         end

--- a/lib/user_agent/browsers/gecko.rb
+++ b/lib/user_agent/browsers/gecko.rb
@@ -26,6 +26,8 @@ class UserAgent
             nil
           elsif /^Windows / =~ comment[0]
             'Windows'
+          elsif comment[1] =~ /^Android/
+            'Android'
           else
             comment[0]
           end

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -150,7 +150,7 @@ describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535
   end
 
   it "should return 'Linux' as its platform" do
-    expect(@useragent.platform).to eq("Linux")
+    expect(@useragent.platform).to eq("Android")
   end
 
   it "should return 'Android 4.2' as its os" do

--- a/spec/browsers/chrome_user_agent_spec.rb
+++ b/spec/browsers/chrome_user_agent_spec.rb
@@ -149,7 +149,7 @@ describe "Mozilla/5.0 (Linux; Android 4.2; Nexus 7 Build/JOP40C) AppleWebKit/535
     expect(@useragent.browser).to eq("Chrome")
   end
 
-  it "should return 'Linux' as its platform" do
+  it "should return 'Android' as its platform" do
     expect(@useragent.platform).to eq("Android")
   end
 


### PR DESCRIPTION
This has been in production for us for a couple months now, and afaik it fixed the case of "linux" showing up for android chrome users. 

I'm opening this PR after it was suggested on #91. I didn't originally open this PR because I wasn't sure if it was technically correct for "Android" to be the platform (is it just the OS? is "linux" actually Android's platform?). At the time I couldn't figure out how to get Android to show for those users, and this seemed the most straightforward.